### PR TITLE
Add Dockerfile for building from a ci-operator job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ build:
 	go build ./cmd/...
 .PHONY: build
 
+install:
+	go install ./cmd/...
+.PHONY: install
+
 test:
 	go test ./...
 .PHONY: test

--- a/OWNERS
+++ b/OWNERS
@@ -1,2 +1,7 @@
 approvers:
+- AlexNPavel
+- bbguimaraes
+- droslean
+- hongkailiu
+- petr-muller
 - stevekuznetsov

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.10
+
+RUN apk add --no-cache ca-certificates
+ADD ci-ns-ttl-controller /ci-ns-ttl-controller
+ENTRYPOINT ["/ci-ns-ttl-controller"]


### PR DESCRIPTION
This initializes the implementation of https://jira.coreos.com/browse/DPTP-647

Take ci-ns-ttl-controller under the umbrella of ci-opearator

/cc @openshift/openshift-team-developer-productivity-test-platform 

/assign @petr-muller 