### PR TITLE
pkg/controller/ttl_manager: Do not block on deleting pods in digestPods

### DIFF
--- a/pkg/controller/ttl_manager.go
+++ b/pkg/controller/ttl_manager.go
@@ -425,7 +425,7 @@ func (c *TTLManager) updateDeleteAtAnnotation(ns *coreapi.Namespace, deleteAt ti
 func digestPods(pods []*coreapi.Pod) (bool, time.Time) {
 	var lastTransitionTime time.Time
 	for _, pod := range pods {
-		if pod.Status.Phase == coreapi.PodPending || pod.Status.Phase == coreapi.PodRunning {
+		if pod.ObjectMeta.DeletionTimestamp == nil && (pod.Status.Phase == coreapi.PodPending || pod.Status.Phase == coreapi.PodRunning) {
 			return true, time.Time{}
 		}
 		for _, status := range pod.Status.ContainerStatuses {
@@ -435,6 +435,9 @@ func digestPods(pods []*coreapi.Pod) (bool, time.Time) {
 					lastTransitionTime = terminationTime
 				}
 			}
+		}
+		if pod.ObjectMeta.DeletionTimestamp != nil && pod.ObjectMeta.DeletionTimestamp.After(lastTransitionTime) {
+			lastTransitionTime = pod.ObjectMeta.DeletionTimestamp.Time
 		}
 	}
 	return false, lastTransitionTime

--- a/pkg/controller/ttl_manager_test.go
+++ b/pkg/controller/ttl_manager_test.go
@@ -527,6 +527,7 @@ func TestDetermineDeleteAt(t *testing.T) {
 }
 
 func TestDigestPods(t *testing.T) {
+	someTime := metav1.NewTime(time.Date(2000, time.January, 1, 1, 1, 1, 0, time.UTC))
 	var testCases = []struct {
 		name                       string
 		pods                       []*coreapi.Pod
@@ -558,6 +559,19 @@ func TestDigestPods(t *testing.T) {
 			}},
 			expectedActive:             true,
 			expectedLastTransitionTime: time.Time{},
+		},
+		{
+			name: "deleting pod",
+			pods: []*coreapi.Pod{{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &someTime,
+				},
+				Status: coreapi.PodStatus{
+					Phase: coreapi.PodRunning,
+				},
+			}},
+			expectedActive:             false,
+			expectedLastTransitionTime: time.Date(2000, time.January, 1, 1, 1, 1, 0, time.UTC),
 		},
 		{
 			name: "terminated pod",


### PR DESCRIPTION
@alvaroaleman [pointed out][1] that pods could have finalizers and similar that keep them from completely deleting.  But as far as "are we ready to remove this namespace?" is concerned, the fact that a pod is working trough the deletion process is enough for it to make it non-blocking.

[1]: https://github.com/openshift/ci-tools/pull/1277#discussion_r501066404