### PR TITLE
Update OWNERS to match openshift/ci-tools

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,16 @@
 approvers:
-- AlexNPavel
 - bbguimaraes
 - droslean
 - hongkailiu
-- petr-muller
-- stevekuznetsov
-- alvaroaleman
+- smg247
+- jmguzik
+- danilo-gemoli
+- bear-redhat
+reviewers:
+- bbguimaraes
+- droslean
+- hongkailiu
+- smg247
+- jmguzik
+- danilo-gemoli
+- bear-redhat


### PR DESCRIPTION
Got pinged on https://github.com/openshift/ci-ns-ttl-controller/pull/11 so `OWNERS` need updating